### PR TITLE
feat(deps):  decouple from "php-http/discovery", replace by friendsofphp/well-know…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "php-http/discovery": "^1.14",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0"
+        "psr/http-factory": "^1.0",
+        "friendsofphp/well-known-implementations": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
@@ -32,7 +32,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "friendsofphp/well-known-implementations": false
+        }
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Skrepr\TeamsConnector;
 
-use Http\Discovery\Exception\NotFoundException;
-use Http\Discovery\Psr18ClientDiscovery;
-use LogicException;
+use FriendsOfPHP\WellKnownImplementations\WellKnownPsr18Client;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Skrepr\TeamsConnector\Exception\InvalidCredentials;
@@ -28,17 +27,9 @@ final class Client
         ClientInterface $client = null,
         RequestBuilder $requestBuilder = null
     ) {
-        if ($client === null) {
-            try {
-                $client = Psr18ClientDiscovery::find();
-            } catch (NotFoundException $e) {
-                throw new LogicException('Could not find any installed HTTP clients. Try installing a package for this list: https://packagist.org/providers/psr/http-client-implementation', 0, $e);
-            }
-        }
-
-        $this->requestBuilder = $requestBuilder ?: new RequestBuilder();
         $this->endPoint = $endPoint;
-        $this->client = $client;
+        $this->client = $client ?? new WellKnownPsr18Client();
+        $this->requestBuilder = $requestBuilder ?? new RequestBuilder();
     }
 
     public function getEndPoint(): string
@@ -47,7 +38,7 @@ final class Client
     }
 
     /**
-     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws ClientExceptionInterface
      */
     public function send(CardInterface $card): void
     {

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Skrepr\TeamsConnector;
 
-use Http\Discovery\Exception\NotFoundException;
-use Http\Discovery\Psr17FactoryDiscovery;
-use LogicException;
+use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -27,29 +25,17 @@ final class RequestBuilder
         RequestFactoryInterface $requestFactory = null,
         StreamFactoryInterface $streamFactory = null
     ) {
-        if ($requestFactory === null || $streamFactory === null) {
-            if (!class_exists(Psr17Factory::class) && !class_exists(Psr17FactoryDiscovery::class)) {
-                throw new LogicException('You cannot use the "%s" as no PSR-17 request factory have been provided. Try running "composer require nyholm/psr7.');
-            }
+        $psr17Factory = new WellKnownPsr17Factory();
 
-            try {
-                $psr17Factory = class_exists(Psr17Factory::class, false) ? new Psr17Factory() : null;
-                $requestFactory = $requestFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findRequestFactory();
-                $streamFactory = $streamFactory ?? $psr17Factory ?? Psr17FactoryDiscovery::findStreamFactory();
-            } catch (NotFoundException $e) {
-                throw new LogicException('You cannot use the "%s" as no PSR-17 request factory have been provided. Try running "composer require nyholm/psr7".', 0, $e);
-            }
-        }
-
-        $this->streamFactory = $streamFactory;
-        $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory ?? $psr17Factory;
+        $this->requestFactory = $requestFactory ?? $psr17Factory;
     }
 
     /**
      * Creates a new PSR-7 request.
      *
-     * @param array $headers name => value or name=>[value]
-     * @param StreamInterface|string|null $body request body
+     * @param array<string, string> $headers
+     * @param StreamInterface|string|null $body
      */
     public function create(string $method, string $uri, array $headers = [], $body = null): RequestInterface
     {


### PR DESCRIPTION
In this PR, I propose to rely on [FriendsOfPHP/well-known-implementations](https://github.com/FriendsOfPHP/well-known-implementations) to ensure a working out-of-the-box experience. This package is a composer-plugin that will install the most suited async-http-implementation depending on the existing dependencies of the projects that require this package

The package also provides a discovery mechanism that covers roughly the same purpose as php-http/discovery, but that plays well with the plugin part of the package.