### PR TITLE
Leverage php-http/discovery v1.15 instead of friendsofphp/well-known-implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0",
-        "friendsofphp/well-known-implementations": "^1.0"
+        "php-http/discovery": "^1.15",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
@@ -34,7 +34,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "friendsofphp/well-known-implementations": false
+            "php-http/discovery": false
         }
     },
     "scripts": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Skrepr\TeamsConnector;
 
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr18Client;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -28,7 +28,7 @@ final class Client
         RequestBuilder $requestBuilder = null
     ) {
         $this->endPoint = $endPoint;
-        $this->client = $client ?? new WellKnownPsr18Client();
+        $this->client = $client ?? Psr18ClientDiscovery::find();
         $this->requestBuilder = $requestBuilder ?? new RequestBuilder();
     }
 

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Skrepr\TeamsConnector;
 
-use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
+use Http\Discovery\Psr17Factory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -25,10 +25,8 @@ final class RequestBuilder
         RequestFactoryInterface $requestFactory = null,
         StreamFactoryInterface $streamFactory = null
     ) {
-        $psr17Factory = new WellKnownPsr17Factory();
-
-        $this->streamFactory = $streamFactory ?? $psr17Factory;
-        $this->requestFactory = $requestFactory ?? $psr17Factory;
+        $this->streamFactory = $streamFactory ?? new Psr17Factory();
+        $this->requestFactory = $requestFactory ?? ($this->streamFactory instanceof RequestFactoryInterface ? $this->streamFactory : new Psr17Factory());
     }
 
     /**


### PR DESCRIPTION
php-http/discovery v1.15 now provides the features of friendsofphp/well-known-implementations, see:
- https://github.com/php-http/discovery/pull/209
- https://github.com/php-http/discovery/pull/208

I therefor plan to discontinue friendsofphp/well-known-implementations.